### PR TITLE
Avoid fetching the whole hic file when range bytes are float numbers

### DIFF
--- a/src/normalizationVector.js
+++ b/src/normalizationVector.js
@@ -50,7 +50,7 @@ class NormalizationVector {
             const adjustedStart = Math.max(0, start - 1000);
             const adjustedEnd = Math.min(this.nValues, end + 1000);
             const startPosition = this.filePosition + adjustedStart * this.dataType;
-            const sizeInBytes = (adjustedEnd - adjustedStart) * this.dataType;
+            const sizeInBytes = Math.ceil(adjustedEnd - adjustedStart) * this.dataType;
             const data = await this.file.read(startPosition, sizeInBytes);
             if (!data) {
                 return undefined;


### PR DESCRIPTION
Hi Jim,

using this config in the `straw-es6.html` will find the code is trying to fetching the whole hic file:
```js
.getContactRecords(
                    "KR",
                    { chr: "8", start: 8530777, end: 44981557 },
                    { chr: "8", start: 8530777, end: 44981557 },
                    "BP",
                    100000
                )
```

ceil the sizeInBytes seems fix this, but not sure if it will cause other issues.
There seems are data in that region with KR norm, but the result table is empty...not sure why.

![image](https://user-images.githubusercontent.com/102806/99932121-bb524f80-2d1c-11eb-860f-ca6d46b81b6a.png)
