### PR TITLE
Remove headers['User-Agent'] = 'straw'

### DIFF
--- a/src/io/remoteFile.js
+++ b/src/io/remoteFile.js
@@ -16,7 +16,7 @@ class RemoteFile {
         headers['Range'] = rangeString
 
         let url = this.url.slice()    // slice => copy
-        headers['User-Agent'] = 'straw'
+        // headers['User-Agent'] = 'straw'
         if (this.config.oauthToken) {
             const token = resolveToken(this.config.oauthToken)
             headers['Authorization'] = `Bearer ${token}`


### PR DESCRIPTION
Remove headers['User-Agent'] = 'straw'. This was throwing a CORS error in Firefox and Safari that prevented loading of HiC files.
