### PR TITLE
Record the transport extension points as ADR-0001

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,36 @@
+# Context — hic-straw
+
+The ubiquitous language of this codebase. When naming a module, a test, an issue
+or a variable, use the term as defined here rather than a synonym.
+
+hic-straw is a **library**, not an application. It reads `.hic` contact map files
+— locally, over HTTP with byte ranges, or as a live stream — and hands contact
+records to consumers. juicebox.js, Spacewalk and igv.js all depend on it. It
+renders nothing and has no UI.
+
+This glossary is grown lazily: terms are added when a decision actually turns on
+them, not upfront.
+
+## Transport
+
+**Remote file** — `src/io/remoteFile.js`, the single place hic-straw reads bytes
+from a URL. Every `.hic` byte-range read in every consumer passes through its
+`read(position, length)`. There is exactly one `fetch` call in the library and it
+is here.
+
+**URL mapper** — the optional `config.mapUrl` function a consumer supplies to
+rewrite a URL before it is fetched. Replaces the built-in rules (Dropbox share
+links, NCBI FTP-to-HTTPS). Synchronous, pure, URL-in URL-out: it cannot touch
+headers, responses or Range semantics. See `docs/adr/0001`.
+
+**Response detail** — the `headers` and `url` properties attached to the `Error`
+thrown on a failed read, alongside the existing `code`. Exists because the status
+code alone can be actively misleading; the header a consumer needs to diagnose
+the failure would otherwise die inside hic-straw. See `docs/adr/0001`.
+
+**Bot challenge** — a data host answering an automated request with a CAPTCHA
+page instead of the file. hic-straw does not detect or interpret these; it
+surfaces the response detail and consumers decide what it means. The known case
+is AWS WAF in front of `www.encodeproject.org`, which serves
+`X-Amzn-Waf-Action: captcha` under a misleading `405` status to any request whose
+`Origin` is not on ENCODE's allowlist.

--- a/docs/adr/0001-transport-extension-points.md
+++ b/docs/adr/0001-transport-extension-points.md
@@ -1,0 +1,85 @@
+# ADR-0001 — Transport extension points on RemoteFile
+
+**Status:** Accepted
+**Date:** 2026-08-01
+
+## Context
+
+`RemoteFile` (`src/io/remoteFile.js`) is the single place hic-straw reads bytes
+from a remote `.hic` file. It calls the global `fetch` directly, and it has two
+properties that consumers cannot work around from the outside:
+
+1. **The URL is fixed at construction.** `mapUrl()` rewrites Dropbox and NCBI FTP
+   URLs, but the rule set is hardcoded. A consumer that needs a different
+   rewrite — for instance routing a request through a local proxy — has no way to
+   supply one.
+2. **The response is discarded on error.** A failed read throws
+   `Error(response.statusText)` carrying only `err.code`. Every response header
+   dies inside hic-straw.
+
+Property 2 has a concrete cost. AWS WAF, which fronts `www.encodeproject.org`,
+answers non-allowlisted origins with a CAPTCHA challenge page and a `405` status.
+The only reliable signal that this happened is the `X-Amzn-Waf-Action: captcha`
+response header. Because hic-straw drops it, every consumer sees a bare
+`405 Method Not Allowed` and no consumer can explain the real failure to a user.
+
+Both properties push consumers toward patching `globalThis.fetch`, which is
+action at a distance, pollutes the host application, and affects transports that
+have nothing to do with hic-straw.
+
+## Decision
+
+Add two extension points to `RemoteFile`, both optional, both carried on the
+existing config object that already flows `new Straw(config)` → `HicFile` args →
+`new RemoteFile(args)`.
+
+**1. `config.mapUrl` — a URL mapping function.**
+
+```js
+this.url = (this.config.mapUrl ?? defaultMapUrl)(args.path || args.url)
+```
+
+The existing hardcoded Dropbox and NCBI rules become `defaultMapUrl`. Supplying
+`mapUrl` replaces them; omitting it changes nothing.
+
+**2. Response detail on the thrown error.**
+
+```js
+const err = Error(response.statusText)
+err.code = status
+err.headers = response.headers
+err.url = url
+throw err
+```
+
+Both are **generic**. hic-straw learns nothing about WAFs, CAPTCHAs, proxies,
+localhost, or any particular data provider. It gains the ability to be told where
+to fetch from, and the obligation to report what it was told when a fetch fails.
+Interpretation belongs to the consumer.
+
+## Consequences
+
+- juicebox.js can route ENCODE requests through a dev-time proxy without patching
+  globals, and can turn `X-Amzn-Waf-Action: captcha` into a message a user can
+  act on. See juicebox.js `docs/adr/0001-dev-proxy-for-waf-protected-hosts.md`,
+  which depends on this decision.
+- Spacewalk, which depends on hic-straw directly as well as through juicebox.js,
+  gets the same two capabilities without a juicebox.js release.
+- `err.headers` is a `Headers` instance, not a plain object. Consumers read it
+  with `err.headers?.get(name)` and must tolerate its absence — errors thrown
+  before a response exists (network failure, abort) have no headers.
+- `mapUrl` is a synchronous pure function of a URL string. It is deliberately not
+  a fetch hook: it cannot set headers, inspect responses, or alter Range
+  semantics. A consumer needing that should be a reason to reopen this ADR, not
+  a reason to widen `mapUrl` quietly.
+- Replacing `defaultMapUrl` rather than composing with it means a consumer who
+  supplies `mapUrl` also inherits responsibility for the Dropbox and NCBI
+  rewrites if their URLs need them. This is the simpler contract; composition can
+  be added later without breaking callers.
+
+## Reversal
+
+Removing either extension point is a breaking change to hic-straw's public
+config once consumers depend on it. `err.headers` is additive and safe to keep
+indefinitely. `mapUrl` would only be removed if hic-straw grew a fuller transport
+abstraction that subsumes it.


### PR DESCRIPTION
RemoteFile fixes its URL at construction and discards the response on error, throwing Error(response.statusText) with only err.code. Consumers can neither redirect a fetch nor see why one failed, which pushes them toward patching globalThis.fetch.

ADR-0001 records two optional extension points on the existing config object: config.mapUrl, generalising the hardcoded Dropbox and NCBI rules, and err.headers / err.url on the thrown error. Both are generic — hic-straw learns nothing about any particular data provider.

The motivating case is AWS WAF in front of encodeproject.org, which answers non-allowlisted origins with a CAPTCHA under a misleading 405. The only reliable signal is a response header that currently dies inside this library.

CONTEXT.md is new, seeded with the transport terms this decision turns on.

Implements: #49
Tracking: aidenlab/juicebox.js#446