### PR TITLE
Replace the withdrawn GEO fixture in the straw tests

### DIFF
--- a/test/straw.test.js
+++ b/test/straw.test.js
@@ -141,20 +141,26 @@ describe('Straw', function () {
 
     }, 100000)
 
-    it('GEO file', async function () {
+    // Normalized query with no NVI supplied, forcing the norm vector index to be
+    // located over the wire.  Must agree with the NVI-supplied case above.
+    //
+    // This replaces a former test against a GEO-hosted fixture
+    // (ftp.ncbi.nlm.nih.gov/geo/samples/GSM2583nnn/GSM2583729) that was withdrawn
+    // upstream and now returns 403.
+    it('remote file contact records - without NVI', async function () {
 
         const straw = new Straw({
-            "url": "https://ftp.ncbi.nlm.nih.gov/geo/samples/GSM2583nnn/GSM2583729/suppl/GSM2583729_H3K27ac_HiChIP_2.hic"
+            "url": "https://raw.githubusercontent.com/igvteam/igv-data/refs/heads/main/data/test/hic/test_chr22.hic"
         })
         const contactRecords = await straw.getContactRecords(
             "KR",
-            {chr: "arm_2L", start: 0, end: 1000000},
-            {chr: "arm_2L", start: 0, end: 1000000},
+            {chr: "22", start: 50000000, end: 100000000},
+            {chr: "22", start: 50000000, end: 100000000},
             "BP",
             100000
         )
 
-        assert.ok(contactRecords.length > 0)
+        assert.equal(contactRecords.length, 70)
 
     }, 100000)
 


### PR DESCRIPTION
## Problem

CI has been red since NCBI withdrew the fixture the `GEO file` test depended on:

```
https://ftp.ncbi.nlm.nih.gov/geo/samples/GSM2583nnn/GSM2583729/suppl/GSM2583729_H3K27ac_HiChIP_2.hic
```

The object now returns **403**, and the parent `suppl/` directory returns 200 but serves an NCBI error page rather than a file listing — so the path is withdrawn, not throttled. Re-running CI will not clear it. Reproduced from two unrelated networks.

This is what is failing PR #51 (the postcss bump), which touches only `package-lock.json` and is unrelated to the failure. Note the second red job there, `build-and-test (20.x)`, reports `The operation was canceled` — that is matrix fail-fast killing the sibling, not an independent failure.

## Why the test was safe to repoint

Added in 2019 as `d428ee7` ("add geo test") with no recorded rationale and no reference anywhere in the repo. Its only distinguishing feature was the arm-style chromosome name `arm_2L`, which turns out to exercise no special code path — the alias table in `src/hicFile.js:184-193` special-cases only `chr`-prefixes and `chrM`, so `arm_2L` resolves by plain exact match in `chromosomeIndexMap` like any other name. Its assertion, `length > 0`, was also the weakest in the file.

## Change

Repoint at the `igv-data` `test_chr22.hic` fixture the neighboring remote tests already use, and give the test real coverage: query `KR` with **no NVI supplied**, forcing the norm vector index to be located over the wire, and assert it returns the same 70 records as the NVI-supplied case above it. That path was not otherwise covered, so this is not a duplicate of `remote file contact records`.

This mirrors the earlier migration off the retired `intra_nofrag_30.hic` fixtures, already noted in the comment above `remote file contact records`.

## Verification

`npm test` locally: **96 passed | 1 skipped (97)**, matching the last green master run (`30713778454`).

## Follow-up, not included here

If you want genuine non-human-genome coverage back, a small committed fixture under `test/data/` would serve better than a live fetch of a third-party file — the local tests already work that way. Happy to file an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)